### PR TITLE
Re-enable support for padded ciphers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+0.2.3
+
+Re-enabled support for padded ciphers
+
 0.2.2
 
 Reverted to disabling padded ciphers https://github.com/kennbr34/evpencutil/pull/7

--- a/configure~
+++ b/configure~
@@ -3244,7 +3244,7 @@ fi
 ac_config_headers="$ac_config_headers config.h"
 
 
-: ${CFLAGS="-g -O4 -Wall -Wno-deprecated -Wno-deprecated-declarations -Wno-overlength-strings -Wno-pointer-sign -Wformat-overflow=0 -fsanitize=undefined"}
+: ${CFLAGS="-g -O0 -Wall -Wno-deprecated -Wno-deprecated-declarations -Wno-overlength-strings -Wno-pointer-sign -Wformat-overflow=0 -fsanitize=undefined"}
 
 # Checks for programs.
 

--- a/scripts/test_ciphers.sh
+++ b/scripts/test_ciphers.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-BUFFER=`echo $(echo $RANDOM)b`
+BUFFER=`echo $(echo $RANDOM | cut -b -4)b`
 COUNT=$(echo $RANDOM)
-BINPATH="./bin/evpencutil-cli -w N=1024"
+BINPATH="./bin/evpencutil-cli -w N=1024 -b file_buffer=$BUFFER"
 
-echo "Testing with $COUNT bytes and default buffer"
+echo "Testing with $COUNT bytes and $BUFFER buffer"
 
 cat $1 | while read cipher ; do
 
@@ -13,7 +13,7 @@ cat $1 | while read cipher ; do
 	dd if=/dev/urandom of=./testfile bs=1 count=$COUNT &> /dev/null
 	$BINPATH -e -i ./testfile -o ./testfile.enc -p password -c "$cipher" &> /dev/null
 	if [ $? != 0 ] ; then
-		echo ""$cipher" failed encryption"
+		#$echo ""$cipher" failed encryption"
 		rm ./testfile ./testfile.enc ./testfile.plain &> /dev/null
 		continue
 	fi

--- a/src/lib.c
+++ b/src/lib.c
@@ -56,8 +56,6 @@ uint8_t isSupportedCipher(uint8_t *cipher)
         strstr(cipher, "idea-ofb") ||
         strstr(cipher, "id-smime-alg-CMS3DESwrap")) {
         return 0;
-    } else if(EVP_CIPHER_get_block_size(EVP_get_cipherbyname(cipher)) > 1) {
-		return 0;
     } else {
         return 1;
     }


### PR DESCRIPTION
Support for padded ciphers is fixed by enforcing proper buffer size (multiple of cipher's block size) as well as handling padding manually. Previous version was not following PCKS#7 scheme properly.